### PR TITLE
Add 'nrf51_dk' to keywords (support for yotta search)

### DIFF
--- a/target.json
+++ b/target.json
@@ -13,6 +13,7 @@
   ],
   "keywords": [
     "mbed-official",
+    "mbed-target:nrf51_dk"
     "gcc"
   ],
   "similarTo": [


### PR DESCRIPTION
# Description

We want this target to be available with `yotta --plain search -k mbed-target:nrf51dk target` command.
