### PR TITLE
Modify target to define ram size in yotta config

### DIFF
--- a/target.json
+++ b/target.json
@@ -2,7 +2,7 @@
   "name": "nrf51dk-gcc",
   "version": "0.0.7",
   "inherits": {
-    "nordic-nrf51822-gcc": "*"
+    "nordic-nrf51822-gcc": "^0.0.1"
   },
   "description": "Official mbed build target for the nRF51-DK 32KB platform.",
   "homepage": "https://github.com/ARMmbed/target-nrf51dk-gcc",

--- a/target.json
+++ b/target.json
@@ -2,7 +2,7 @@
   "name": "nrf51dk-gcc",
   "version": "0.0.7",
   "inherits": {
-    "nordic-nrf51822-32k-gcc": "*"
+    "nordic-nrf51822-gcc": "*"
   },
   "description": "Official mbed build target for the nRF51-DK 32KB platform.",
   "homepage": "https://github.com/ARMmbed/target-nrf51dk-gcc",
@@ -25,6 +25,14 @@
     "nrf51dk"
   ],
   "config": {
+    "nrf51822": {
+        "ram_size": "32K"
+    },
+    "image": {
+      "heap": {
+        "warning_threshold": 1024
+      }
+    },
     "hardware": {
       "pins": {
         "LED1": "p21",


### PR DESCRIPTION
This target now makes use of the new family target nordic-nrf51822-gcc.